### PR TITLE
docs: Add troubleshooting notes for macOS

### DIFF
--- a/docs/5.2-local-setup.md
+++ b/docs/5.2-local-setup.md
@@ -342,3 +342,8 @@ If tests fail or containers become corrupted:
 ```
 
 This will remove all containers, prune volumes, and recreate the network.
+
+### Compatibility with macOS
+To run the test suite locally on macOS you need `bash` version >4.x and `gnu-sed`. A more recent version of bash is needed to fix a problem with associative arrays in shell scripts. Likewise on macOS the options for `sed` behave differently. To ensure correct execution of the shell scripts, `gnu-sed` can be used.
+
+Both `bash` and `gnu-sed` are installable with `brew`. Additionally `gnu-sed` should be added to the PATH environment by adding it to `~/.zshrc`. The installed dir for the replacement `sed` executable is usually `/opt/homebrew/opt/gnu-sed/libexec/gnubin`.


### PR DESCRIPTION
I ran into problems when trying to execute the test suite locally on macOS and these are my workarounds.